### PR TITLE
Binary map bugfixes

### DIFF
--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -30,7 +30,7 @@ void BinarySensorMap::process_group_() {
     if (bs.binary_sensor->state) {
       num_active_sensors++;
       total_current_value += bs.sensor_value;
-      mask |= 1 << i;
+      mask |= 1ULL << i;
     }
   }
   // check if the sensor map was touched
@@ -58,7 +58,7 @@ void BinarySensorMap::process_sum_() {
     auto bs = this->channels_[i];
     if (bs.binary_sensor->state) {
       total_current_value += bs.sensor_value;
-      mask |= 1 << i;
+      mask |= 1ULL << i;
     }
   }
 

--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -38,12 +38,11 @@ void BinarySensorMap::process_group_() {
     // did the bit_mask change or is it a new sensor touch
     if (this->last_mask_ != mask) {
       float publish_value = total_current_value / num_active_sensors;
-      ESP_LOGD(TAG, "'%s' - Publishing %.2f", this->name_.c_str(), publish_value);
       this->publish_state(publish_value);
     }
   } else if (this->last_mask_ != 0ULL) {
     // is this a new sensor release
-    ESP_LOGD(TAG, "'%s' - No binary sensor active, publishing NAN", this->name_.c_str());
+    ESP_LOGV(TAG, "'%s' - No binary sensor active, publishing NAN", this->name_.c_str());
     this->publish_state(NAN);
   }
   this->last_mask_ = mask;
@@ -66,12 +65,11 @@ void BinarySensorMap::process_sum_() {
     // did the bit_mask change or is it a new sensor touch
     if (this->last_mask_ != mask) {
       float publish_value = total_current_value;
-      ESP_LOGD(TAG, "'%s' - Publishing %.2f", this->name_.c_str(), publish_value);
       this->publish_state(publish_value);
     }
   } else if (this->last_mask_ != 0ULL) {
     // is this a new sensor release
-    ESP_LOGD(TAG, "'%s' - No binary sensor active, publishing 0", this->name_.c_str());
+    ESP_LOGV(TAG, "'%s' - No binary sensor active, publishing 0", this->name_.c_str());
     this->publish_state(0.0);
   }
   this->last_mask_ = mask;

--- a/esphome/components/binary_sensor_map/sensor.py
+++ b/esphome/components/binary_sensor_map/sensor.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = cv.typed_schema(
         ).extend(
             {
                 cv.Required(CONF_CHANNELS): cv.All(
-                    cv.ensure_list(entry), cv.Length(min=1)
+                    cv.ensure_list(entry), cv.Length(min=1, max=64)
                 ),
             }
         ),
@@ -50,7 +50,7 @@ CONFIG_SCHEMA = cv.typed_schema(
         ).extend(
             {
                 cv.Required(CONF_CHANNELS): cv.All(
-                    cv.ensure_list(entry), cv.Length(min=1)
+                    cv.ensure_list(entry), cv.Length(min=1, max=64)
                 ),
             }
         ),


### PR DESCRIPTION
# What does this implement/fix?

The binary sensor map component with SUM type outputs NAN if all the binary_sensory channels are off on boot.
If one channel turns on and off, the sensor then outputs 0.0. This PR has the sensor output 0.0 on boot if all the channels are off when using the SUM type.
(This gives a different result for this particular case, but this PR seems to be the intended behavior. I am unsure if I should mark it as a breaking change because of this.)

The component has a max of 64 binary_sensor channels, as a uint64_t stores each binary state as a bit. Therefore, the sensor.py configuration should limit the number of binary_sensor channels to 64.

The current component logs at the debug level whenever the sensor updates. ESPHome already logs the state of the sensor whenever it is updated, so this is redundant. I removed two log output commands for regular sensor updates and changed one to log at the verbose level to describe why the sensor outputs NAN when using the group type.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
switch:
  - platform: template
    name: "switch 1"
    id: switch_1
    optimistic: true
binary_sensor:
  - platform: template
    id: binary_sensor_1
    name: "binary sensor 1"
    lambda: |-
      return id(switch_1).state;
sensor:
  - platform: binary_sensor_map
    name: 'sum'
    type: SUM
    channels:
      - binary_sensor: binary_sensor_1
        value: 2
# the 'sum' sensor originally sent NAN on boot. If you toggle the switch on and off, then it would send 0.0. This PR sends 0.0 on boot.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
