### PR TITLE
Add Bayesian type to binary sensor map sensor

### DIFF
--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -16,6 +16,9 @@ void BinarySensorMap::loop() {
     case BINARY_SENSOR_MAP_TYPE_SUM:
       this->process_sum_();
       break;
+    case BINARY_SENSOR_MAP_TYPE_BAYESIAN:
+      this->process_bayesian_();
+      break;
   }
 }
 
@@ -23,25 +26,27 @@ void BinarySensorMap::process_group_() {
   float total_current_value = 0.0;
   uint8_t num_active_sensors = 0;
   uint64_t mask = 0x00;
-  // check all binary_sensors for its state. when active add its value to total_current_value.
-  // create a bitmask for the binary_sensor status on all channels
+  // - check all binary_sensors for its state
+  //  - if active, add its value to total_current_value.
+  // - creates a bitmask for the binary_sensor status on all channels
   for (size_t i = 0; i < this->channels_.size(); i++) {
     auto bs = this->channels_[i];
     if (bs.binary_sensor->state) {
       num_active_sensors++;
-      total_current_value += bs.sensor_value;
+      total_current_value += bs.parameters.sensor_value;
       mask |= 1ULL << i;
     }
   }
-  // check if the sensor map was touched
+
+  // potentially update state only if a binary_sensor is active
   if (mask != 0ULL) {
-    // did the bit_mask change or is it a new sensor touch
+    // publish the average if the bitmask has changed
     if (this->last_mask_ != mask) {
       float publish_value = total_current_value / num_active_sensors;
       this->publish_state(publish_value);
     }
   } else if (this->last_mask_ != 0ULL) {
-    // is this a new sensor release
+    // no buttons are pressed, so publish NAN
     ESP_LOGV(TAG, "'%s' - No binary sensor active, publishing NAN", this->name_.c_str());
     this->publish_state(NAN);
   }
@@ -52,12 +57,12 @@ void BinarySensorMap::process_sum_() {
   float total_current_value = 0.0;
   uint64_t mask = 0x00;
   // - check all binary_sensor states
-  // - if active, add its value to total_current_value
+  //  - if active, add its value to total_current_value
   // - creates a bitmask for the binary_sensor status on all channels
   for (size_t i = 0; i < this->channels_.size(); i++) {
     auto bs = this->channels_[i];
     if (bs.binary_sensor->state) {
-      total_current_value += bs.sensor_value;
+      total_current_value += bs.parameters.sensor_value;
       mask |= 1ULL << i;
     }
   }
@@ -70,15 +75,66 @@ void BinarySensorMap::process_sum_() {
   this->last_mask_ = mask;
 }
 
+void BinarySensorMap::process_bayesian_() {
+  float posterior_probability = this->bayesian_prior_;
+  uint8_t num_active_sensors = 0;
+  uint64_t mask = 0x00;
+
+  // - check all binary_sensors states
+  // - compute the posterior probability by multiplying by the predicate for each sensor
+  // - create a bitmask for the binary_sensor status on all channels
+  for (size_t i = 0; i < this->channels_.size(); i++) {
+    auto bs = this->channels_[i];
+
+    posterior_probability *=
+        this->bayesian_predicate_(bs.binary_sensor->state, posterior_probability,
+                                  bs.parameters.probabilities.given_true, bs.parameters.probabilities.given_false);
+
+    mask |= (bs.binary_sensor->state) << i;
+  }
+
+  // update state only if the binary sensor states have changed or if no state has ever been sent on boot
+  if ((this->last_mask_ != mask) || (!this->has_state())) {
+    this->publish_state(posterior_probability);
+  }
+
+  this->last_mask_ = mask;
+}
+
+float BinarySensorMap::bayesian_predicate_(bool sensor_state, float prior, float prob_given_true,
+                                           float prob_given_false) {
+  float prob_state_source_true = prob_given_true;
+  float prob_state_source_false = prob_given_false;
+
+  if (!sensor_state) {
+    prob_state_source_true = 1 - prob_given_true;
+    prob_state_source_false = 1 - prob_given_false;
+  }
+
+  return prob_state_source_true / (prior * prob_state_source_true + (1.0 - prior) * prob_state_source_false);
+}
+
 void BinarySensorMap::add_channel(binary_sensor::BinarySensor *sensor, float value) {
   BinarySensorMapChannel sensor_channel{
       .binary_sensor = sensor,
-      .sensor_value = value,
+      .parameters{
+          .sensor_value = value,
+      },
   };
   this->channels_.push_back(sensor_channel);
 }
 
-void BinarySensorMap::set_sensor_type(BinarySensorMapType sensor_type) { this->sensor_type_ = sensor_type; }
-
+void BinarySensorMap::add_channel(binary_sensor::BinarySensor *sensor, float prob_given_true, float prob_given_false) {
+  BinarySensorMapChannel sensor_channel{
+      .binary_sensor = sensor,
+      .parameters{
+          .probabilities{
+              .given_true = prob_given_true,
+              .given_false = prob_given_false,
+          },
+      },
+  };
+  this->channels_.push_back(sensor_channel);
+}
 }  // namespace binary_sensor_map
 }  // namespace esphome

--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -80,7 +80,6 @@ void BinarySensorMap::process_sum_() {
 
 void BinarySensorMap::process_bayesian_() {
   float posterior_probability = this->bayesian_prior_;
-  uint8_t num_active_sensors = 0;
   uint64_t mask = 0x00;
 
   // - compute the posterior probability by taking the product of the predicate probablities for each observation

--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -60,7 +60,7 @@ void BinarySensorMap::process_sum_() {
   uint64_t mask = 0x00;
 
   // - check all binary_sensor states
-  //  - if active, add its value to total_current_value
+  // - if active, add its value to total_current_value
   // - creates a bitmask for the binary_sensor states on all channels
   for (size_t i = 0; i < this->channels_.size(); i++) {
     auto bs = this->channels_[i];

--- a/esphome/components/binary_sensor_map/binary_sensor_map.cpp
+++ b/esphome/components/binary_sensor_map/binary_sensor_map.cpp
@@ -26,6 +26,7 @@ void BinarySensorMap::process_group_() {
   float total_current_value = 0.0;
   uint8_t num_active_sensors = 0;
   uint64_t mask = 0x00;
+
   // - check all binary_sensors for its state
   //  - if active, add its value to total_current_value.
   // - creates a bitmask for the binary_sensor status on all channels
@@ -46,16 +47,18 @@ void BinarySensorMap::process_group_() {
       this->publish_state(publish_value);
     }
   } else if (this->last_mask_ != 0ULL) {
-    // no buttons are pressed, so publish NAN
+    // no buttons are pressed and the states have changed since last run, so publish NAN
     ESP_LOGV(TAG, "'%s' - No binary sensor active, publishing NAN", this->name_.c_str());
     this->publish_state(NAN);
   }
+
   this->last_mask_ = mask;
 }
 
 void BinarySensorMap::process_sum_() {
   float total_current_value = 0.0;
   uint64_t mask = 0x00;
+
   // - check all binary_sensor states
   //  - if active, add its value to total_current_value
   // - creates a bitmask for the binary_sensor status on all channels
@@ -67,7 +70,7 @@ void BinarySensorMap::process_sum_() {
     }
   }
 
-  // update state only if the binary sensor states have changed or if no state has ever been sent on boot
+  // update state only if the binary_sensor states have changed or if no state has ever been sent on boot
   if ((this->last_mask_ != mask) || (!this->has_state())) {
     this->publish_state(total_current_value);
   }
@@ -90,10 +93,10 @@ void BinarySensorMap::process_bayesian_() {
         this->bayesian_predicate_(bs.binary_sensor->state, posterior_probability,
                                   bs.parameters.probabilities.given_true, bs.parameters.probabilities.given_false);
 
-    mask |= (bs.binary_sensor->state) << i;
+    mask |= ((uint64_t) (bs.binary_sensor->state)) << i;
   }
 
-  // update state only if the binary sensor states have changed or if no state has ever been sent on boot
+  // update state only if the binary_sensor states have changed or if no state has ever been sent on boot
   if ((this->last_mask_ != mask) || (!this->has_state())) {
     this->publish_state(posterior_probability);
   }

--- a/esphome/components/binary_sensor_map/sensor.py
+++ b/esphome/components/binary_sensor_map/sensor.py
@@ -20,14 +20,26 @@ BinarySensorMap = binary_sensor_map_ns.class_(
 )
 SensorMapType = binary_sensor_map_ns.enum("SensorMapType")
 
+CONF_BAYESIAN = "bayesian"
+CONF_PRIOR = "prior"
+CONF_PROB_GIVEN_TRUE = "prob_given_true"
+CONF_PROB_GIVEN_FALSE = "prob_given_false"
+
 SENSOR_MAP_TYPES = {
     CONF_GROUP: SensorMapType.BINARY_SENSOR_MAP_TYPE_GROUP,
     CONF_SUM: SensorMapType.BINARY_SENSOR_MAP_TYPE_SUM,
+    CONF_BAYESIAN: SensorMapType.BINARY_SENSOR_MAP_TYPE_BAYESIAN,
 }
 
-entry = {
+entry_one_parameter = {
     cv.Required(CONF_BINARY_SENSOR): cv.use_id(binary_sensor.BinarySensor),
     cv.Required(CONF_VALUE): cv.float_,
+}
+
+entry_bayesian_parameters = {
+    cv.Required(CONF_BINARY_SENSOR): cv.use_id(binary_sensor.BinarySensor),
+    cv.Required(CONF_PROB_GIVEN_TRUE): cv.float_range(min=0, max=1),
+    cv.Required(CONF_PROB_GIVEN_FALSE): cv.float_range(min=0, max=1),
 }
 
 CONFIG_SCHEMA = cv.typed_schema(
@@ -39,7 +51,7 @@ CONFIG_SCHEMA = cv.typed_schema(
         ).extend(
             {
                 cv.Required(CONF_CHANNELS): cv.All(
-                    cv.ensure_list(entry), cv.Length(min=1, max=64)
+                    cv.ensure_list(entry_one_parameter), cv.Length(min=1, max=64)
                 ),
             }
         ),
@@ -50,7 +62,18 @@ CONFIG_SCHEMA = cv.typed_schema(
         ).extend(
             {
                 cv.Required(CONF_CHANNELS): cv.All(
-                    cv.ensure_list(entry), cv.Length(min=1, max=64)
+                    cv.ensure_list(entry_one_parameter), cv.Length(min=1, max=64)
+                ),
+            }
+        ),
+        CONF_BAYESIAN: sensor.sensor_schema(
+            BinarySensorMap,
+            accuracy_decimals=2,
+        ).extend(
+            {
+                cv.Required(CONF_PRIOR): cv.float_range(min=0, max=1),
+                cv.Required(CONF_CHANNELS): cv.All(
+                    cv.ensure_list(entry_bayesian_parameters), cv.Length(min=1, max=64)
                 ),
             }
         ),
@@ -66,6 +89,16 @@ async def to_code(config):
     constant = SENSOR_MAP_TYPES[config[CONF_TYPE]]
     cg.add(var.set_sensor_type(constant))
 
+    if config[CONF_TYPE] == CONF_BAYESIAN:
+        cg.add(var.set_bayesian_prior(config[CONF_PRIOR]))
+
     for ch in config[CONF_CHANNELS]:
         input_var = await cg.get_variable(ch[CONF_BINARY_SENSOR])
-        cg.add(var.add_channel(input_var, ch[CONF_VALUE]))
+        if config[CONF_TYPE] == CONF_BAYESIAN:
+            cg.add(
+                var.add_channel(
+                    input_var, ch[CONF_PROB_GIVEN_TRUE], ch[CONF_PROB_GIVEN_FALSE]
+                )
+            )
+        else:
+            cg.add(var.add_channel(input_var, ch[CONF_VALUE]))

--- a/esphome/components/binary_sensor_map/sensor.py
+++ b/esphome/components/binary_sensor_map/sensor.py
@@ -24,6 +24,7 @@ CONF_BAYESIAN = "bayesian"
 CONF_PRIOR = "prior"
 CONF_PROB_GIVEN_TRUE = "prob_given_true"
 CONF_PROB_GIVEN_FALSE = "prob_given_false"
+CONF_OBSERVATIONS = "observations"
 
 SENSOR_MAP_TYPES = {
     CONF_GROUP: SensorMapType.BINARY_SENSOR_MAP_TYPE_GROUP,
@@ -72,7 +73,7 @@ CONFIG_SCHEMA = cv.typed_schema(
         ).extend(
             {
                 cv.Required(CONF_PRIOR): cv.float_range(min=0, max=1),
-                cv.Required(CONF_CHANNELS): cv.All(
+                cv.Required(CONF_OBSERVATIONS): cv.All(
                     cv.ensure_list(entry_bayesian_parameters), cv.Length(min=1, max=64)
                 ),
             }
@@ -91,14 +92,15 @@ async def to_code(config):
 
     if config[CONF_TYPE] == CONF_BAYESIAN:
         cg.add(var.set_bayesian_prior(config[CONF_PRIOR]))
-
-    for ch in config[CONF_CHANNELS]:
-        input_var = await cg.get_variable(ch[CONF_BINARY_SENSOR])
-        if config[CONF_TYPE] == CONF_BAYESIAN:
+        
+        for obs in config[CONF_OBSERVATIONS]:
+            input_var = await cg.get_variable(obs[CONF_BINARY_SENSOR])
             cg.add(
                 var.add_channel(
-                    input_var, ch[CONF_PROB_GIVEN_TRUE], ch[CONF_PROB_GIVEN_FALSE]
+                    input_var, obs[CONF_PROB_GIVEN_TRUE], obs[CONF_PROB_GIVEN_FALSE]
                 )
             )
-        else:
+    else:    
+        for ch in config[CONF_CHANNELS]:
+            input_var = await cg.get_variable(ch[CONF_BINARY_SENSOR])
             cg.add(var.add_channel(input_var, ch[CONF_VALUE]))

--- a/esphome/components/binary_sensor_map/sensor.py
+++ b/esphome/components/binary_sensor_map/sensor.py
@@ -92,7 +92,7 @@ async def to_code(config):
 
     if config[CONF_TYPE] == CONF_BAYESIAN:
         cg.add(var.set_bayesian_prior(config[CONF_PRIOR]))
-        
+
         for obs in config[CONF_OBSERVATIONS]:
             input_var = await cg.get_variable(obs[CONF_BINARY_SENSOR])
             cg.add(
@@ -100,7 +100,7 @@ async def to_code(config):
                     input_var, obs[CONF_PROB_GIVEN_TRUE], obs[CONF_PROB_GIVEN_FALSE]
                 )
             )
-    else:    
+    else:
         for ch in config[CONF_CHANNELS]:
             input_var = await cg.get_variable(ch[CONF_BINARY_SENSOR])
             cg.add(var.add_channel(input_var, ch[CONF_VALUE]))

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -368,6 +368,32 @@ sensor:
       - binary_sensor: bin3
         value: 100.0
 
+  - platform: binary_sensor_map
+    name: Binary Sensor Map
+    type: sum
+    channels:
+      - binary_sensor: bin1
+        value: 10.0
+      - binary_sensor: bin2
+        value: 15.0
+      - binary_sensor: bin3
+        value: 100.0
+
+  - platform: binary_sensor_map
+    name: Binary Sensor Map
+    type: bayesian
+    prior: 0.4
+    observations:
+      - binary_sensor: bin1
+        prob_given_true: 0.9
+        prob_given_false: 0.4
+      - binary_sensor: bin2
+        prob_given_true: 0.7
+        prob_given_false: 0.05
+      - binary_sensor: bin3
+        prob_given_true: 0.8
+        prob_given_false: 0.2
+
   - platform: bl0939
     uart_id: uart_8
     voltage:


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for mapping one or more binary_sensor's states to a Bayesian probability, much like Home Assistant's Bayesian sensor. The comments for the other types have been modified to improve clarity and uniformity throughout the code. Tests have been added for the existing SUM type and the new BAYESIAN type to test3.yaml.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

sensor:
  - platform: binary_sensor_map
    id: bayesian_prob
    name: 'Bayesian Event Probability'
    type: bayesian
    prior: 0.4
    observations:
      - binary_sensor: binary_sensor_0
        prob_given_true: 0.9
        prob_given_false: 0.2
      - binary_sensor: binary_sensor_1
        prob_given_true: 0.6
        prob_given_false: 0.1

binary_sensor:
  - platform: template
    id: binary_sensor_0
    name: "binary sensor 0"
    lambda: |-
      return id(switch_0).state;
  - platform: template
    id: binary_sensor_1
    name: "binary sensor 1"
    lambda: |-
      return id(switch_1).state;      

switch:
  - platform: template
    name: "switch 0"
    id: switch_0
    optimistic: true
  - platform: template
    name: "switch 1"
    id: switch_1
    optimistic: true   

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
